### PR TITLE
Fix the encoder DTX control

### DIFF
--- a/opuslib/classes.py
+++ b/opuslib/classes.py
@@ -318,4 +318,6 @@ class Encoder(object):
         self.encoder_state, opuslib.api.ctl.get_dtx)
 
     _set_dtx = lambda self, x: opuslib.api.encoder.encoder_ctl(
-        self.encoder_state, opuslib.api.ctl.get_dtx, x)
+        self.encoder_state, opuslib.api.ctl.set_dtx, x)
+
+    dtx = property(_get_dtx, _set_dtx)


### PR DESCRIPTION
This adds a property for the DTX control of the encoder and fixes the `_set_dtx` function.
