### PR TITLE
Add argtypes to libopus_ctl.

### DIFF
--- a/opuslib/api/decoder.py
+++ b/opuslib/api/decoder.py
@@ -297,6 +297,7 @@ def decode_float(  # pylint: disable=too-many-arguments
 
 
 libopus_ctl = opuslib.api.libopus.opus_decoder_ctl
+libopus_ctl.argtypes = (DecoderPointer, ctypes.c_int,)
 libopus_ctl.restype = ctypes.c_int
 
 

--- a/opuslib/api/encoder.py
+++ b/opuslib/api/encoder.py
@@ -70,6 +70,7 @@ def create_state(fs: int, channels: int, application: int) -> ctypes.Structure:
 
 
 libopus_ctl = opuslib.api.libopus.opus_encoder_ctl
+libopus_ctl.argtypes = (EncoderPointer, ctypes.c_int,)
 libopus_ctl.restype = ctypes.c_int
 
 


### PR DESCRIPTION
On aarch64-darwin, argtypes for variadic functions need to be specified according to https://bugs.python.org/issue42880#msg384901. Without it, segmentation faults occur at runtime.