### PR TITLE
Allow set_inband_fec(2) in tests.

### DIFF
--- a/tests/encoder.py
+++ b/tests/encoder.py
@@ -247,7 +247,7 @@ class EncoderTest(unittest.TestCase):
         self.check_setget(
             opuslib.api.ctl.set_inband_fec,
             opuslib.api.ctl.get_inband_fec,
-            (-1, 2),
+            (-1, 3),
             (1, 0)
         )
 


### PR DESCRIPTION
This is allowed in libopus 1.4:

https://github.com/xiph/opus/commit/3acaa70965c5570ef1711fee9b3a15eac3e74ffe